### PR TITLE
- update ThreadSleep accuracy

### DIFF
--- a/Shuttle.Core.Infrastructure/ThreadSleep.cs
+++ b/Shuttle.Core.Infrastructure/ThreadSleep.cs
@@ -25,18 +25,18 @@ namespace Shuttle.Core.Infrastructure
                 step = MaxStepSize;
 
             // end time
-            var end = DateTime.Now.AddMilliseconds(ms);
+            var end = DateTime.UtcNow.AddMilliseconds(ms);
             
             // sleep time should be 
             // 1) as large as possible to reduce burden on the os and improve accuracy
             // 2) less than the max step size to keep the thread responsive to thread state
 
-            var remaining = (int)(end - DateTime.Now).TotalMilliseconds;
+            var remaining = (int)(end - DateTime.UtcNow).TotalMilliseconds;
             while (state.Active && remaining > 0)
             {
                 var sleep = remaining < step ? remaining : step;
                 Thread.Sleep(sleep);
-                remaining = (int)(end - DateTime.Now).TotalMilliseconds;
+                remaining = (int)(end - DateTime.UtcNow).TotalMilliseconds;
             }
         }
     }

--- a/Shuttle.Core.Infrastructure/ThreadSleep.cs
+++ b/Shuttle.Core.Infrastructure/ThreadSleep.cs
@@ -1,23 +1,42 @@
+using System;
 using System.Threading;
 
 namespace Shuttle.Core.Infrastructure
 {
     public static class ThreadSleep
     {
+        public const int MaxStepSize = 1000;
+
         public static void While(int ms, IThreadState state)
         {
-            While(ms, state, 5);
+            // step size should be as large as possible,
+            // max step size by default
+            While(ms, state, MaxStepSize);
         }
 
         public static void While(int ms, IThreadState state, int step)
         {
-            var elapsed = 0;
+            // don't sleep less than zero
+            if (ms < 0)
+                return;
 
-            while (state.Active && elapsed < ms)
+            // step size must be positive and less than max step size
+            if (step < 0 || step > MaxStepSize)
+                step = MaxStepSize;
+
+            // end time
+            var end = DateTime.Now.AddMilliseconds(ms);
+            
+            // sleep time should be 
+            // 1) as large as possible to reduce burden on the os and improve accuracy
+            // 2) less than the max step size to keep the thread responsive to thread state
+
+            var remaining = (int)(end - DateTime.Now).TotalMilliseconds;
+            while (state.Active && remaining > 0)
             {
-                Thread.Sleep(step);
-
-                elapsed += step;
+                var sleep = remaining < step ? remaining : step;
+                Thread.Sleep(sleep);
+                remaining = (int)(end - DateTime.Now).TotalMilliseconds;
             }
         }
     }


### PR DESCRIPTION
We were seeing highly inaccruate sleep times in several environements.  On some server up to 3x more sleep time than specificied.  This helps improve accuracy based on time calculations instead of number of steps.