### PR TITLE
Test fix

### DIFF
--- a/Shuttle.Core.Infrastructure.Tests/StreamExtensionsFixture.cs
+++ b/Shuttle.Core.Infrastructure.Tests/StreamExtensionsFixture.cs
@@ -34,7 +34,7 @@ namespace Shuttle.Core.Infrastructure.Tests
 
             Assert.AreEqual(5, copy.Length);
             Assert.AreEqual(0, copy.Position);
-            Assert.AreEqual(0, copy.Position);
+            Assert.AreEqual(5, stream.Position);
         }
     }
 }


### PR DESCRIPTION
the `Assert.AreEqual(0, copy.Position);` was checked twice. Probably you wanted to write this.